### PR TITLE
deps: pin llama-stack floor to 0.2.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "llama-stack @ git+https://github.com/meta-llama/llama-stack.git@release-0.2.2",
+    "llama-stack>=0.2.5",
     "kubernetes",
     "fastapi",
     "opentelemetry-api",


### PR DESCRIPTION
Latest released version of Llama Stack has external provider support