### PR TITLE
fix: correct import error and downgrade Python version to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "llama-stack-provider-lmeval"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 dependencies = [
     "llama-stack>=0.2.5",
     "kubernetes",

--- a/src/llama_stack_provider_lmeval/config.py
+++ b/src/llama_stack_provider_lmeval/config.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional, Any, Union
 from pydantic import Field
 
 from llama_stack.apis.eval import BenchmarkConfig, EvalCandidate
-from src.llama_stack_provider_lmeval.errors import LMEvalConfigError
+from .errors import LMEvalConfigError
 from llama_stack.schema_utils import json_schema_type
 
 


### PR DESCRIPTION
This PR makes the following changes: 
* Corrects the import error in `lmeval.py` by replacing the absolute path with the local path
* Addresses #12 by downgrading to Python 3.10