### PR TITLE
feat: Add support for tokenized_requests from the benchmark invocation

### DIFF
--- a/src/llama_stack_provider_lmeval/lmeval.py
+++ b/src/llama_stack_provider_lmeval/lmeval.py
@@ -424,6 +424,18 @@ class LMEvalCRBuilder:
                 logger.debug(f"Using custom tokenizer from metadata: {tokenizer_value}")
                 model_args.append(ModelArg(name="tokenizer", value=tokenizer_value))
 
+        # Add tokenized_requests parameter if present in metadata
+        if (
+            hasattr(task_config, "metadata")
+            and task_config.metadata
+            and "tokenized_requests" in task_config.metadata
+        ):
+            tokenized_requests_value = task_config.metadata.get("tokenized_requests")
+            if isinstance(tokenized_requests_value, (bool, str)) and tokenized_requests_value is not None:
+                value_str = str(tokenized_requests_value)
+                logger.debug(f"Using tokenized_requests from metadata: {value_str}")
+                model_args.append(ModelArg(name="tokenized_requests", value=value_str))
+
         # Collect environment variables
         env_vars = self._collect_env_vars(task_config, stored_benchmark)
 

--- a/tests/test_lmeval.py
+++ b/tests/test_lmeval.py
@@ -186,6 +186,39 @@ class TestLMEvalCRBuilder(unittest.TestCase):
             "Tokenizer value should match the value specified in the request's metadata",
         )
 
+    @patch("src.llama_stack_provider_lmeval.lmeval.logger")
+    def test_create_cr_with_tokenized_requests(self, mock_logger):
+        """Creating CR with tokenized_requests specified in metadata."""
+        config = LMEvalEvalProviderConfig(
+            namespace=self.namespace,
+            service_account=self.service_account,
+        )
+        self.builder._config = config
+
+        self.benchmark_config.metadata = {"tokenized_requests": False}
+
+        cr = self.builder.create_cr(
+            benchmark_id="lmeval::mmlu",
+            task_config=self.benchmark_config,
+            base_url="http://my-model-url",
+            limit="10",
+            stored_benchmark=self.stored_benchmark,
+        )
+
+        model_args = cr.get("spec", {}).get("modelArgs", [])
+        tokenized_requests_args = [arg for arg in model_args if arg.get("name") == "tokenized_requests"]
+
+        self.assertEqual(
+            len(tokenized_requests_args),
+            1,
+            "tokenized_requests should be present when specified in the request's metadata",
+        )
+        self.assertEqual(
+            tokenized_requests_args[0].get("value"),
+            "False",
+            "tokenized_requests value should match the value specified in the request's metadata",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Add support for setting `tokenized_requests` on benchmark configuration.

Example:

```python
client.benchmarks.register(
    benchmark_id="lmeval::dk-bench",
    dataset_id="lmeval::dk-bench",
    scoring_functions=["string"],
    provider_benchmark_id="string",
    provider_id="lmeval",
    metadata={
        # ... Other fields ...
        "tokenized_requests": False,
    },
)
```