### PR TITLE
fix: Add tokenizer options

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ It also includes an end-to-end instructions demonstratring how one can use LM-Ev
 
 9. Start the llama stack server in a virtual enviornment
     ```
-    llama stack run ../run.yaml --image-type venv
+    llama stack run run.yaml --image-type venv
     ```
 
     Expected output:

--- a/src/llama_stack_provider_lmeval/config.py
+++ b/src/llama_stack_provider_lmeval/config.py
@@ -75,10 +75,12 @@ class LMEvalEvalProviderConfig:
     # Service account to use for Kubernetes deployment
     service_account: Optional[str] = None
     # Default tokenizer to use when none is specified in the ModelCandidate
-    default_tokenizer: str = "google/flan-t5-base"
+    tokenizer: str = "google/flan-t5-base"
     metadata: Optional[Dict[str, Any]] = None
     # Optional TLS certificate path (or False, to disable TLS verification)
     tls: Optional[Union[str, bool]] = None
+    # Tokenize requests (by default, set to False, to disable tokenization)
+    tokenized_requests: bool = False
 
     def __post_init__(self):
         """Validate the configuration"""
@@ -95,6 +97,9 @@ class LMEvalEvalProviderConfig:
             raise LMEvalConfigError(
                 "tls must be either a string path to a certificate or False"
             )
+        #  Validate tokenizer setting
+        if not isinstance(self.tokenized_requests, bool):
+            raise LMEvalConfigError("tokenized_requests must be a boolean")
 
 
 __all__ = ["LMEvalBenchmarkConfig", "K8sLMEvalConfig", "LMEvalEvalProviderConfig"]

--- a/src/llama_stack_provider_lmeval/lmeval.py
+++ b/src/llama_stack_provider_lmeval/lmeval.py
@@ -185,6 +185,22 @@ class LMEvalCRBuilder:
 
         model_args.append(ModelArg(name="num_concurrent", value="1"))
 
+        # Add tokenized requests parameter if present in config
+        if hasattr(self._config, "tokenized_requests") and self._config.tokenized_requests is not None:
+            tokenized_requests_value = str(self._config.tokenized_requests)
+            logger.debug(
+                f"Adding tokenized_requests to CR: {tokenized_requests_value}"
+            )
+            model_args.append(ModelArg(name="tokenized_requests", value=tokenized_requests_value))
+
+        #  Add tokenizer if specified in the config
+        if hasattr(self._config, "tokenizer") and self._config.tokenizer is not None:
+            tokenizer_name  = str(self._config.tokenizer)
+            logger.debug(
+                f"Adding tokenized_requests to CR: {tokenizer_name}"
+            )
+            model_args.append(ModelArg(name="tokenizer", value=tokenizer_name))
+
         return model_args
 
     def _collect_env_vars(


### PR DESCRIPTION
This PR addresses #15 by making the following changes:
* Adds option to enable tokenized requests in the config, by default it is disabled
* Adds option to configure a specific tokenizer, by default the tokenizer is `google/flan-t5-base`