### PR TITLE
feat: Implement namespace resolution in LMEval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
 src/llama_stack_provider_lmeval.egg-info/*
 src/llama_stack_provider_lmeval/__pycache__/
-/.idea/inspectionProfiles/profiles_settings.xml
-/.idea/inspectionProfiles/Project_Default.xml
-/.idea/.gitignore
-/.idea/llama-stack-provider-lmeval.iml
-/.idea/misc.xml
-/.idea/modules.xml
-/.idea/vcs.xml
+.idea
+.mypy_cache/
+build/
+.pytest_cache/
+__pycache__/

--- a/src/llama_stack_provider_lmeval/lmeval.py
+++ b/src/llama_stack_provider_lmeval/lmeval.py
@@ -526,9 +526,11 @@ def _resolve_namespace(config: LMEvalEvalProviderConfig) -> str:
 
     """  # noqa: D205, E501
     # Check if namespace is explicitly set in the provider config
-    if hasattr(config, "namespace") and config.namespace:
-        logger.debug(f"Using namespace from provider config: {config.namespace}")
-        return config.namespace
+    if hasattr(config, "namespace") and isinstance(config.namespace, str):
+        namespace = config.namespace.strip()
+        if namespace:
+            logger.debug(f"Using namespace from provider config: {namespace}")
+            return namespace
 
     # Check from environment variable
     env_namespace = os.getenv('TRUSTYAI_LM_EVAL_NAMESPACE')  # noqa: Q000

--- a/src/llama_stack_provider_lmeval/lmeval.py
+++ b/src/llama_stack_provider_lmeval/lmeval.py
@@ -1,21 +1,22 @@
 from __future__ import annotations
 
-import logging
 import json
-import yaml
-from datetime import datetime
+import logging
+import os
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+import yaml
 from kubernetes import client as k8s_client
 from kubernetes import config as k8s_config
 from kubernetes.client.rest import ApiException
-from pydantic import BaseModel, Field
-
 from llama_stack.apis.benchmarks import Benchmark, ListBenchmarksResponse
 from llama_stack.apis.common.job_types import Job, JobStatus
 from llama_stack.apis.eval import BenchmarkConfig, Eval, EvaluateResponse
 from llama_stack.apis.scoring import ScoringResult
 from llama_stack.providers.datatypes import BenchmarksProtocolPrivate
+from pydantic import BaseModel
+
 from .config import LMEvalEvalProviderConfig
 from .errors import LMEvalConfigError, LMEvalTaskNameError
 
@@ -511,11 +512,72 @@ class LMEvalCRBuilder:
         return cr_dict
 
 
+def _resolve_namespace(config: LMEvalEvalProviderConfig) -> str:
+    """Resolve the namespace.
+    1. Namespace check in the provider config
+    2. If missing, read from environment variable TRUSTYAI_LM_EVAL_NAMESPACE
+    3. If all above missing, use current namespace from service account or pod environment.
+
+    Args:
+        config: The LMEval provider configuration
+
+    Returns:
+        The resolved namespace string
+
+    """  # noqa: D205, E501
+    # Check if namespace is explicitly set in the provider config
+    if hasattr(config, "namespace") and config.namespace:
+        logger.debug(f"Using namespace from provider config: {config.namespace}")
+        return config.namespace
+
+    # Check from environment variable
+    env_namespace = os.getenv('TRUSTYAI_LM_EVAL_NAMESPACE')  # noqa: Q000
+    if env_namespace:
+        logger.debug(f"Using namespace from environment variable: {env_namespace}")
+        return env_namespace
+
+    # Check from service account namespace file
+    service_account_namespace_path = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+    if Path(service_account_namespace_path).exists():
+        try:
+            with open(service_account_namespace_path, 'r') as f:
+                namespace = f.read().strip()
+                if namespace:
+                    logger.debug(f"Using namespace from service account: {namespace}")
+                    return namespace
+        except Exception as e:
+            logger.warning(f"Failed to read namespace from service account: {e}")
+
+    # Check for POD_NAMESPACE environment variable
+    pod_namespace = os.getenv("POD_NAMESPACE")
+    if pod_namespace:
+        logger.debug(f"Using namespace from POD_NAMESPACE environment variable: {pod_namespace}")
+        return pod_namespace
+
+    # Check for NAMESPACE environment variable
+    alt_namespace = os.getenv('NAMESPACE')  # noqa: Q000
+    if alt_namespace:
+        logger.debug(f"Using namespace from NAMESPACE environment variable: {alt_namespace}")
+        return alt_namespace
+
+    # No namespace found - fail explicitly
+    raise LMEvalConfigError(  # noqa: TRY003
+        "Unable to determine namespace. Please specify one of the following:\n"  # noqa: EM101
+        "1. Set 'namespace' in your run.yaml provider config\n"
+        "2. Set TRUSTYAI_LM_EVAL_NAMESPACE environment variable\n"
+        "3. Ensure pod has access to service account namespace file\n"
+        "4. Set POD_NAMESPACE or NAMESPACE environment variables",
+    )
+
+
 class LMEval(Eval, BenchmarksProtocolPrivate):
     def __init__(self, config: LMEvalEvalProviderConfig):
         self._config = config
+        
+        self._namespace = _resolve_namespace(self._config)
+        
         logger.debug(
-            f"LMEval provider initialized with namespace: {getattr(self._config, 'namespace', 'default')}"
+            f"LMEval provider initialized with namespace: {self._namespace}"
         )
         logger.debug(f"LMEval provider config values: {vars(self._config)}")
         self.benchmarks = {}
@@ -524,7 +586,6 @@ class LMEval(Eval, BenchmarksProtocolPrivate):
 
         self._k8s_client = None
         self._k8s_custom_api = None
-        self._namespace = getattr(self._config, "namespace", "default")
         logger.debug(f"Initialized Kubernetes client with namespace: {self._namespace}")
         if self.use_k8s:
             self._init_k8s_client()

--- a/src/llama_stack_provider_lmeval/lmeval.py
+++ b/src/llama_stack_provider_lmeval/lmeval.py
@@ -547,7 +547,7 @@ def _resolve_namespace(config: LMEvalEvalProviderConfig) -> str:
                 if namespace:
                     logger.debug(f"Using namespace from service account: {namespace}")
                     return namespace
-        except Exception as e:
+        except OSError as e:
             logger.warning(f"Failed to read namespace from service account: {e}")
 
     # Check for POD_NAMESPACE environment variable

--- a/src/llama_stack_provider_lmeval/lmeval.py
+++ b/src/llama_stack_provider_lmeval/lmeval.py
@@ -588,9 +588,9 @@ class LMEval(Eval, BenchmarksProtocolPrivate):
 
         self._k8s_client = None
         self._k8s_custom_api = None
-        logger.debug(f"Initialized Kubernetes client with namespace: {self._namespace}")
         if self.use_k8s:
             self._init_k8s_client()
+            logger.debug(f"Initialized Kubernetes client with namespace: {self._namespace}")
             self._cr_builder = LMEvalCRBuilder(
                 namespace=self._namespace,
                 service_account=getattr(self._config, "service_account", None),

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -114,6 +114,24 @@ class TestNamespaceResolution(unittest.TestCase):
         mock_logger.debug.assert_called_with("Using namespace from POD_NAMESPACE environment variable: pod-namespace")
 
     @patch('llama_stack_provider_lmeval.lmeval.Path')
+    def test_namespace_from_namespace_env_var(self, mock_path):
+        """Test namespace resolution from NAMESPACE environment variable."""
+        class MockConfig:
+            pass
+        
+        config = MockConfig()
+        os.environ['NAMESPACE'] = 'generic-namespace'
+        
+        mock_path_instance = mock_path.return_value
+        mock_path_instance.exists.return_value = False
+        
+        with patch('llama_stack_provider_lmeval.lmeval.logger') as mock_logger:
+            namespace = _resolve_namespace(config)
+            
+        self.assertEqual(namespace, "generic-namespace")
+        mock_logger.debug.assert_called_with("Using namespace from NAMESPACE environment variable: generic-namespace")
+
+    @patch('llama_stack_provider_lmeval.lmeval.Path')
     def test_namespace_resolution_priority(self, mock_path):
         """Test that namespace resolution follows right order."""
         config = LMEvalEvalProviderConfig(namespace="config-namespace")

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -1,0 +1,154 @@
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import patch, mock_open
+import sys
+sys.path.insert(0, 'src')
+
+from llama_stack_provider_lmeval.config import LMEvalEvalProviderConfig
+from llama_stack_provider_lmeval.errors import LMEvalConfigError
+from llama_stack_provider_lmeval.lmeval import _resolve_namespace
+
+
+class TestNamespaceResolution(unittest.TestCase):
+    """Test the namespace resolution."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        env_vars_to_clear = [
+            'TRUSTYAI_LM_EVAL_NAMESPACE',
+            'POD_NAMESPACE', 
+            'NAMESPACE'
+        ]
+        for var in env_vars_to_clear:
+            if var in os.environ:
+                del os.environ[var]
+
+    def tearDown(self):
+        """Clean up after each test."""
+        env_vars_to_clear = [
+            'TRUSTYAI_LM_EVAL_NAMESPACE',
+            'POD_NAMESPACE',
+            'NAMESPACE'
+        ]
+        for var in env_vars_to_clear:
+            if var in os.environ:
+                del os.environ[var]
+
+    def test_namespace_from_provider_config(self):
+        """Test namespace resolution from provider config."""
+        config = LMEvalEvalProviderConfig(namespace="test-namespace")
+        
+        with patch('llama_stack_provider_lmeval.lmeval.logger') as mock_logger:
+            namespace = _resolve_namespace(config)
+            
+        self.assertEqual(namespace, "test-namespace")
+        mock_logger.debug.assert_called_with("Using namespace from provider config: test-namespace")
+
+    def test_namespace_respects_any_config_value(self):
+        """Test that any namespace value in provider config is respected."""
+        config = LMEvalEvalProviderConfig(namespace="default")
+        
+        with patch('llama_stack_provider_lmeval.lmeval.logger') as mock_logger:
+            namespace = _resolve_namespace(config)
+            
+        self.assertEqual(namespace, "default")
+        mock_logger.debug.assert_called_with("Using namespace from provider config: default")
+        
+        config_test = LMEvalEvalProviderConfig(namespace="test")
+        
+        with patch('llama_stack_provider_lmeval.lmeval.logger') as mock_logger:
+            namespace = _resolve_namespace(config_test)
+            
+        self.assertEqual(namespace, "test")
+        mock_logger.debug.assert_called_with("Using namespace from provider config: test")
+
+    def test_namespace_from_trustyai_env_var(self):
+        """Test namespace resolution from TRUSTYAI_LM_EVAL_NAMESPACE environment variable."""
+        class MockConfig:
+            pass
+        
+        config = MockConfig()
+        os.environ['TRUSTYAI_LM_EVAL_NAMESPACE'] = 'trustyai-namespace'
+        
+        with patch('llama_stack_provider_lmeval.lmeval.logger') as mock_logger:
+            namespace = _resolve_namespace(config)
+            
+        self.assertEqual(namespace, "trustyai-namespace")
+        mock_logger.debug.assert_called_with("Using namespace from environment variable: trustyai-namespace")
+
+    @patch('llama_stack_provider_lmeval.lmeval.Path')
+    def test_namespace_from_service_account_file(self, mock_path):
+        """Test namespace resolution from service account file."""
+        class MockConfig:
+            pass
+        
+        config = MockConfig()
+        
+        mock_path_instance = mock_path.return_value
+        mock_path_instance.exists.return_value = True
+        
+        with patch('builtins.open', mock_open(read_data='service-account-namespace')):
+            with patch('llama_stack_provider_lmeval.lmeval.logger') as mock_logger:
+                namespace = _resolve_namespace(config)
+        
+        self.assertEqual(namespace, "service-account-namespace")
+        mock_logger.debug.assert_called_with("Using namespace from service account: service-account-namespace")
+
+    @patch('llama_stack_provider_lmeval.lmeval.Path')
+    def test_namespace_from_pod_namespace_env_var(self, mock_path):
+        """Test namespace resolution from POD_NAMESPACE environment variable."""
+        class MockConfig:
+            pass
+        
+        config = MockConfig()
+        os.environ['POD_NAMESPACE'] = 'pod-namespace'
+        
+        mock_path_instance = mock_path.return_value
+        mock_path_instance.exists.return_value = False
+        
+        with patch('llama_stack_provider_lmeval.lmeval.logger') as mock_logger:
+            namespace = _resolve_namespace(config)
+            
+        self.assertEqual(namespace, "pod-namespace")
+        mock_logger.debug.assert_called_with("Using namespace from POD_NAMESPACE environment variable: pod-namespace")
+
+    @patch('llama_stack_provider_lmeval.lmeval.Path')
+    def test_namespace_resolution_priority(self, mock_path):
+        """Test that namespace resolution follows right order."""
+        config = LMEvalEvalProviderConfig(namespace="config-namespace")
+        os.environ['TRUSTYAI_LM_EVAL_NAMESPACE'] = 'trustyai-namespace'
+        os.environ['POD_NAMESPACE'] = 'pod-namespace'
+        
+        mock_path_instance = mock_path.return_value
+        mock_path_instance.exists.return_value = True
+        
+        with patch('builtins.open', mock_open(read_data='service-account-namespace')):
+            with patch('llama_stack_provider_lmeval.lmeval.logger') as mock_logger:
+                namespace = _resolve_namespace(config)
+        
+        self.assertEqual(namespace, "config-namespace")
+        mock_logger.debug.assert_called_with("Using namespace from provider config: config-namespace")
+
+    @patch('llama_stack_provider_lmeval.lmeval.Path')
+    def test_namespace_resolution_failure(self, mock_path):
+        """Test that function raises exception when no namespace is found."""
+        class MockConfig:
+            pass
+        
+        config = MockConfig()
+        
+        mock_path_instance = mock_path.return_value
+        mock_path_instance.exists.return_value = False
+        
+        with self.assertRaises(LMEvalConfigError) as context:
+            _resolve_namespace(config)
+        
+        error_msg = str(context.exception)
+        self.assertIn("Unable to determine namespace", error_msg)
+        self.assertIn("Set 'namespace' in your run.yaml provider config", error_msg)
+        self.assertIn("Set TRUSTYAI_LM_EVAL_NAMESPACE environment variable", error_msg)
+
+
+if __name__ == '__main__':
+    unittest.main() 

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -96,6 +96,44 @@ class TestNamespaceResolution(unittest.TestCase):
         mock_logger.debug.assert_called_with("Using namespace from service account: service-account-namespace")
 
     @patch('llama_stack_provider_lmeval.lmeval.Path')
+    def test_namespace_from_empty_service_account_file(self, mock_path):
+        """Test namespace resolution when service account file is empty or whitespace."""
+        class MockConfig:
+            pass
+        
+        config = MockConfig()
+        os.environ['TRUSTYAI_LM_EVAL_NAMESPACE'] = 'trustyai-namespace'
+        
+        mock_path_instance = mock_path.return_value
+        mock_path_instance.exists.return_value = True
+        
+        with patch('builtins.open', mock_open(read_data='')):
+            with patch('llama_stack_provider_lmeval.lmeval.logger') as mock_logger:
+                namespace = _resolve_namespace(config)
+        
+        self.assertEqual(namespace, "trustyai-namespace")
+        mock_logger.debug.assert_called_with("Using namespace from environment variable: trustyai-namespace")
+
+    @patch('llama_stack_provider_lmeval.lmeval.Path')
+    def test_namespace_from_whitespace_service_account_file(self, mock_path):
+        """Test namespace resolution when service account file contains only whitespace."""
+        class MockConfig:
+            pass
+        
+        config = MockConfig()
+        os.environ['POD_NAMESPACE'] = 'pod-namespace'
+        
+        mock_path_instance = mock_path.return_value
+        mock_path_instance.exists.return_value = True
+        
+        with patch('builtins.open', mock_open(read_data='   \n\t  ')):
+            with patch('llama_stack_provider_lmeval.lmeval.logger') as mock_logger:
+                namespace = _resolve_namespace(config)
+        
+        self.assertEqual(namespace, "pod-namespace")
+        mock_logger.debug.assert_called_with("Using namespace from POD_NAMESPACE environment variable: pod-namespace")
+
+    @patch('llama_stack_provider_lmeval.lmeval.Path')
     def test_namespace_from_pod_namespace_env_var(self, mock_path):
         """Test namespace resolution from POD_NAMESPACE environment variable."""
         class MockConfig:


### PR DESCRIPTION
## Summary by Sourcery

Implement namespace resolution in LMEval provider to determine the Kubernetes namespace from multiple sources and integrate it into the LMEval initialization

New Features:
- Add `_resolve_namespace` function to select namespace from provider config, environment variables, service account file, or fallback variables
- Update LMEval initializer to use the resolved namespace instead of directly reading from config

Enhancements:
- Improve logging to display the resolved namespace source during initialization

Tests:
- Add unit tests for namespace resolution covering all priority paths and failure case