### PR TITLE
fix: honour config namespace

### DIFF
--- a/src/llama_stack_provider_lmeval/config.py
+++ b/src/llama_stack_provider_lmeval/config.py
@@ -70,7 +70,7 @@ class LMEvalEvalProviderConfig:
     use_k8s: bool = True
     # FIXME: Hardcoded just for debug purposes
     base_url: str = "http://llamastack-service:8321"
-    namespace: str = "test"
+    namespace: str | None = None
     kubeconfig_path: Optional[str] = None
     # Service account to use for Kubernetes deployment
     service_account: Optional[str] = None

--- a/src/llama_stack_provider_lmeval/lmeval.py
+++ b/src/llama_stack_provider_lmeval/lmeval.py
@@ -526,11 +526,9 @@ def _resolve_namespace(config: LMEvalEvalProviderConfig) -> str:
 
     """  # noqa: D205, E501
     # Check if namespace is explicitly set in the provider config
-    if hasattr(config, "namespace") and isinstance(config.namespace, str):
-        namespace = config.namespace.strip()
-        if namespace:
-            logger.debug(f"Using namespace from provider config: {namespace}")
-            return namespace
+    if config.namespace:
+        logger.debug(f"Using namespace from provider config: {config.namespace}")
+        return config.namespace.strip()
 
     # Check from environment variable
     env_namespace = os.getenv('TRUSTYAI_LM_EVAL_NAMESPACE')  # noqa: Q000

--- a/tests/test_namespace.py
+++ b/tests/test_namespace.py
@@ -65,10 +65,7 @@ class TestNamespaceResolution(unittest.TestCase):
 
     def test_namespace_from_trustyai_env_var(self):
         """Test namespace resolution from TRUSTYAI_LM_EVAL_NAMESPACE environment variable."""
-        class MockConfig:
-            pass
-        
-        config = MockConfig()
+        config = LMEvalEvalProviderConfig()
         os.environ['TRUSTYAI_LM_EVAL_NAMESPACE'] = 'trustyai-namespace'
         
         with patch('llama_stack_provider_lmeval.lmeval.logger') as mock_logger:
@@ -80,10 +77,7 @@ class TestNamespaceResolution(unittest.TestCase):
     @patch('llama_stack_provider_lmeval.lmeval.Path')
     def test_namespace_from_service_account_file(self, mock_path):
         """Test namespace resolution from service account file."""
-        class MockConfig:
-            pass
-        
-        config = MockConfig()
+        config = LMEvalEvalProviderConfig()
         
         mock_path_instance = mock_path.return_value
         mock_path_instance.exists.return_value = True
@@ -98,10 +92,8 @@ class TestNamespaceResolution(unittest.TestCase):
     @patch('llama_stack_provider_lmeval.lmeval.Path')
     def test_namespace_from_empty_service_account_file(self, mock_path):
         """Test namespace resolution when service account file is empty or whitespace."""
-        class MockConfig:
-            pass
-        
-        config = MockConfig()
+
+        config = LMEvalEvalProviderConfig()
         os.environ['TRUSTYAI_LM_EVAL_NAMESPACE'] = 'trustyai-namespace'
         
         mock_path_instance = mock_path.return_value
@@ -117,10 +109,8 @@ class TestNamespaceResolution(unittest.TestCase):
     @patch('llama_stack_provider_lmeval.lmeval.Path')
     def test_namespace_from_whitespace_service_account_file(self, mock_path):
         """Test namespace resolution when service account file contains only whitespace."""
-        class MockConfig:
-            pass
         
-        config = MockConfig()
+        config = LMEvalEvalProviderConfig()
         os.environ['POD_NAMESPACE'] = 'pod-namespace'
         
         mock_path_instance = mock_path.return_value
@@ -136,10 +126,7 @@ class TestNamespaceResolution(unittest.TestCase):
     @patch('llama_stack_provider_lmeval.lmeval.Path')
     def test_namespace_from_pod_namespace_env_var(self, mock_path):
         """Test namespace resolution from POD_NAMESPACE environment variable."""
-        class MockConfig:
-            pass
-        
-        config = MockConfig()
+        config = LMEvalEvalProviderConfig()
         os.environ['POD_NAMESPACE'] = 'pod-namespace'
         
         mock_path_instance = mock_path.return_value
@@ -154,10 +141,7 @@ class TestNamespaceResolution(unittest.TestCase):
     @patch('llama_stack_provider_lmeval.lmeval.Path')
     def test_namespace_from_namespace_env_var(self, mock_path):
         """Test namespace resolution from NAMESPACE environment variable."""
-        class MockConfig:
-            pass
-        
-        config = MockConfig()
+        config = LMEvalEvalProviderConfig()
         os.environ['NAMESPACE'] = 'generic-namespace'
         
         mock_path_instance = mock_path.return_value
@@ -189,10 +173,7 @@ class TestNamespaceResolution(unittest.TestCase):
     @patch('llama_stack_provider_lmeval.lmeval.Path')
     def test_namespace_resolution_failure(self, mock_path):
         """Test that function raises exception when no namespace is found."""
-        class MockConfig:
-            pass
-        
-        config = MockConfig()
+        config = LMEvalEvalProviderConfig()
         
         mock_path_instance = mock_path.return_value
         mock_path_instance.exists.return_value = False


### PR DESCRIPTION
We removed the default value of config so we can fallback to env var and SA namespace file if not found.
config.namespace attribute will always exist since it's a class field.

## Summary by Sourcery

Update config.namespace to be optional without a default value and streamline the namespace resolution logic to prefer the provider config and then fall back to the environment variable.

Bug Fixes:
- Honour explicit provider config namespace and fallback to environment variable when no namespace is set.

Enhancements:
- Remove hardcoded default namespace and change config.namespace default to None.
- Simplify namespace resolution by removing redundant attribute checks and using direct truthiness tests.