### PR TITLE
chore: Bump minimum Python version to 3.12

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "llama-stack-provider-lmeval"
 version = "0.1.5"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
     "llama-stack>=0.2.5",
     "kubernetes",


### PR DESCRIPTION
## Summary by Sourcery

Bump the project’s minimum Python version to 3.12 across CI workflows and metadata

Enhancements:
- Update GitHub Actions build-and-push workflow to use Python 3.12
- Update GitHub Actions security workflow to use Python 3.12
- Raise pyproject.toml’s requires-python to >=3.12