### PR TITLE
feat: update LLS version to 0.2.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "llama-stack>=0.2.5",
+    "llama-stack>=0.2.16",
     "kubernetes",
     "fastapi",
     "opentelemetry-api",

--- a/src/llama_stack_provider_lmeval/provider.py
+++ b/src/llama_stack_provider_lmeval/provider.py
@@ -12,7 +12,7 @@ def get_provider_spec() -> ProviderSpec:
         adapter=AdapterSpec(
             name="trustyai_lmeval",
             pip_packages=["kubernetes"],
-            config_class="config.LMEvalBenchmarkConfig",
+            config_class="lmeval.config.LMEvalBenchmarkConfig",
             module="lmeval",
         ),
     )


### PR DESCRIPTION
Updates the config class to the full path of the module in order to use the`get_provider_spec` function properly

## Summary by Sourcery

Update project version and llama-stack dependency, and fix config class reference for provider spec

Bug Fixes:
- Use full module path for config_class in get_provider_spec

Enhancements:
- Bump project version to 0.1.8
- Upgrade llama-stack dependency to >=0.2.16