### PR TITLE
fix: chat completions endpoint

### DIFF
--- a/src/llama_stack_provider_lmeval/__init__.py
+++ b/src/llama_stack_provider_lmeval/__init__.py
@@ -1,7 +1,9 @@
 import logging
 from typing import Dict, Optional
 
-from llama_stack.distribution.datatypes import Api, ProviderSpec
+from llama_stack.apis.datatypes import Api
+from llama_stack.providers.datatypes import ProviderSpec
+
 from .config import LMEvalEvalProviderConfig
 from .lmeval import LMEval
 from .provider import get_provider_spec

--- a/src/llama_stack_provider_lmeval/lmeval.py
+++ b/src/llama_stack_provider_lmeval/lmeval.py
@@ -172,9 +172,9 @@ class LMEvalCRBuilder:
         
         # Check if URL already ends with v1
         if cleaned_url.endswith("/v1"):
-            return f"{cleaned_url}/openai/v1/completions"
+            return f"{cleaned_url}/chat/completions"
         else:
-            return f"{cleaned_url}/v1/openai/v1/completions"
+            return f"{cleaned_url}/v1/chat/completions"
 
     def _create_model_args(
         self, model_name: str, base_url: Optional[str] = None

--- a/tests/test_base_url_handling.py
+++ b/tests/test_base_url_handling.py
@@ -25,71 +25,71 @@ class TestBaseUrlHandling(unittest.TestCase):
     def test_build_openai_url_regular_url(self):
         """Test building OpenAI URL from regular base URL."""
         result = LMEvalCRBuilder._build_openai_url(BASE_URL)
-        self.assertEqual(result, f"{BASE_URL}/v1/openai/v1/completions")
+        self.assertEqual(result, f"{BASE_URL}/v1/chat/completions")
 
     def test_build_openai_url_with_v1_ending(self):
         """Test building OpenAI URL when base URL ends with /v1."""
         base_url = f"{BASE_URL}/v1"
         result = LMEvalCRBuilder._build_openai_url(base_url)
-        self.assertEqual(result, f"{BASE_URL}/v1/openai/v1/completions")
+        self.assertEqual(result, f"{BASE_URL}/v1/chat/completions")
 
     def test_build_openai_url_with_v1_slash_ending(self):
         """Test building OpenAI URL when base URL ends with /v1/."""
         base_url = f"{BASE_URL}/v1/"
         result = LMEvalCRBuilder._build_openai_url(base_url)
-        self.assertEqual(result, f"{BASE_URL}/v1/openai/v1/completions")
+        self.assertEqual(result, f"{BASE_URL}/v1/chat/completions")
 
     def test_build_openai_url_with_multiple_trailing_slashes(self):
         """Test building OpenAI URL with multiple trailing slashes."""
         base_url = f"{BASE_URL}///"
         result = LMEvalCRBuilder._build_openai_url(base_url)
-        self.assertEqual(result, f"{BASE_URL}/v1/openai/v1/completions")
+        self.assertEqual(result, f"{BASE_URL}/v1/chat/completions")
 
     def test_build_openai_url_with_v1_and_multiple_slashes(self):
         """Test building OpenAI URL when base URL ends with /v1/// (multiple slashes)."""
         base_url = f"{BASE_URL}/v1///"
         result = LMEvalCRBuilder._build_openai_url(base_url)
-        self.assertEqual(result, f"{BASE_URL}/v1/openai/v1/completions")
+        self.assertEqual(result, f"{BASE_URL}/v1/chat/completions")
 
     def test_build_openai_url_complex_path_with_v1(self):
         """Test building OpenAI URL with complex path ending in v1."""
         base_url = "https://api.example.com:8080/some/path/v1"
         result = LMEvalCRBuilder._build_openai_url(base_url)
-        self.assertEqual(result, "https://api.example.com:8080/some/path/v1/openai/v1/completions")
+        self.assertEqual(result, "https://api.example.com:8080/some/path/v1/chat/completions")
 
     def test_build_openai_url_v1_in_middle(self):
         """Test building OpenAI URL when v1 appears in middle but not at end."""
         base_url = f"{BASE_URL}/v1/something/else"
         result = LMEvalCRBuilder._build_openai_url(base_url)
-        self.assertEqual(result, f"{BASE_URL}/v1/something/else/v1/openai/v1/completions")
+        self.assertEqual(result, f"{BASE_URL}/v1/something/else/v1/chat/completions")
 
     def test_build_openai_url_case_sensitivity(self):
         """Test that the v1 check is case sensitive."""
         base_url = f"{BASE_URL}/V1"
         result = LMEvalCRBuilder._build_openai_url(base_url)
         # Should treat V1 as different from v1
-        self.assertEqual(result, f"{BASE_URL}/V1/v1/openai/v1/completions")
+        self.assertEqual(result, f"{BASE_URL}/V1/v1/chat/completions")
 
     def test_build_openai_url_with_v1_and_query_params(self):
         """Test building OpenAI URL when base URL ends with /v1 and has query parameters."""
         base_url = f"{BASE_URL}/v1?param=value&other=test"
         result = LMEvalCRBuilder._build_openai_url(base_url)
         # Query parameters should be preserved but v1 not detected at end
-        self.assertEqual(result, f"{BASE_URL}/v1?param=value&other=test/v1/openai/v1/completions")
+        self.assertEqual(result, f"{BASE_URL}/v1?param=value&other=test/v1/chat/completions")
 
     def test_build_openai_url_with_v1_and_fragment(self):
         """Test building OpenAI URL when base URL ends with /v1 and has fragment."""
         base_url = f"{BASE_URL}/v1#section"
         result = LMEvalCRBuilder._build_openai_url(base_url)
         # Fragment should be preserved but v1 not detected at end
-        self.assertEqual(result, f"{BASE_URL}/v1#section/v1/openai/v1/completions")
+        self.assertEqual(result, f"{BASE_URL}/v1#section/v1/chat/completions")
 
     def test_build_openai_url_with_v1_query_params_and_fragment(self):
         """Test building OpenAI URL when base URL ends with /v1 and has both query params and fragment."""
         base_url = f"{BASE_URL}/v1?param=value#section"
         result = LMEvalCRBuilder._build_openai_url(base_url)
         # Both query params and fragment should be preserved but v1 not detected at end
-        self.assertEqual(result, f"{BASE_URL}/v1?param=value#section/v1/openai/v1/completions")
+        self.assertEqual(result, f"{BASE_URL}/v1?param=value#section/v1/chat/completions")
 
     # Tests for the _create_model_args method integration
     def test_create_model_args_without_base_url(self):
@@ -127,7 +127,7 @@ class TestBaseUrlHandling(unittest.TestCase):
         # Check base_url arg
         base_url_arg = next((arg for arg in result if arg.name == "base_url"), None)
         self.assertIsNotNone(base_url_arg)
-        self.assertEqual(base_url_arg.value, f"{BASE_URL}/v1/openai/v1/completions")
+        self.assertEqual(base_url_arg.value, f"{BASE_URL}/v1/chat/completions")
 
     def test_create_model_args_with_base_url_ending_with_v1(self):
         """Test creating model args with base_url ending with /v1."""
@@ -142,7 +142,7 @@ class TestBaseUrlHandling(unittest.TestCase):
         # Check base_url arg
         base_url_arg = next((arg for arg in result if arg.name == "base_url"), None)
         self.assertIsNotNone(base_url_arg)
-        self.assertEqual(base_url_arg.value, f"{BASE_URL}/v1/openai/v1/completions")
+        self.assertEqual(base_url_arg.value, f"{BASE_URL}/v1/chat/completions")
 
     def test_create_model_args_with_base_url_ending_with_slash_v1(self):
         """Test creating model args with base_url ending with /v1/ (trailing slash)."""
@@ -157,7 +157,7 @@ class TestBaseUrlHandling(unittest.TestCase):
         # Check base_url arg - trailing slash should be stripped first, then v1 detected
         base_url_arg = next((arg for arg in result if arg.name == "base_url"), None)
         self.assertIsNotNone(base_url_arg)
-        self.assertEqual(base_url_arg.value, f"{BASE_URL}/v1/openai/v1/completions")
+        self.assertEqual(base_url_arg.value, f"{BASE_URL}/v1/chat/completions")
 
     def test_create_model_args_with_complex_base_url_ending_with_v1(self):
         """Test creating model args with complex base_url ending with /v1."""
@@ -172,7 +172,7 @@ class TestBaseUrlHandling(unittest.TestCase):
         # Check base_url arg
         base_url_arg = next((arg for arg in result if arg.name == "base_url"), None)
         self.assertIsNotNone(base_url_arg)
-        self.assertEqual(base_url_arg.value, "https://api.example.com:8080/some/path/v1/openai/v1/completions")
+        self.assertEqual(base_url_arg.value, "https://api.example.com:8080/some/path/v1/chat/completions")
 
     def test_create_model_args_with_base_url_containing_v1_but_not_ending(self):
         """Test creating model args with base_url containing v1 but not ending with it."""
@@ -187,7 +187,7 @@ class TestBaseUrlHandling(unittest.TestCase):
         # Check base_url arg - should get full /v1/openai/v1/completions since it doesn't end with v1
         base_url_arg = next((arg for arg in result if arg.name == "base_url"), None)
         self.assertIsNotNone(base_url_arg)
-        self.assertEqual(base_url_arg.value, f"{BASE_URL}/v1/something/else/v1/openai/v1/completions")
+        self.assertEqual(base_url_arg.value, f"{BASE_URL}/v1/something/else/v1/chat/completions")
 
     def test_create_model_args_with_empty_base_url(self):
         """Test creating model args with empty base_url."""
@@ -216,7 +216,7 @@ class TestBaseUrlHandling(unittest.TestCase):
         # Check base_url arg - trailing slashes should be stripped
         base_url_arg = next((arg for arg in result if arg.name == "base_url"), None)
         self.assertIsNotNone(base_url_arg)
-        self.assertEqual(base_url_arg.value, f"{BASE_URL}/v1/openai/v1/completions")
+        self.assertEqual(base_url_arg.value, f"{BASE_URL}/v1/chat/completions")
 
     def test_create_model_args_with_v1_and_trailing_slashes(self):
         """Test creating model args with base_url ending with v1 and trailing slashes."""
@@ -231,7 +231,7 @@ class TestBaseUrlHandling(unittest.TestCase):
         # Check base_url arg - trailing slashes should be stripped first, then v1 detected
         base_url_arg = next((arg for arg in result if arg.name == "base_url"), None)
         self.assertIsNotNone(base_url_arg)
-        self.assertEqual(base_url_arg.value, f"{BASE_URL}/v1/openai/v1/completions")
+        self.assertEqual(base_url_arg.value, f"{BASE_URL}/v1/chat/completions")
 
     def test_model_arg_type_consistency(self):
         """Test that all returned objects are ModelArg instances."""


### PR DESCRIPTION
## Summary by Sourcery

Fix the completions endpoint path in the URL builder to use chat/completions instead of openai/v1/completions and update all related tests accordingly.

Bug Fixes:
- Change the _build_openai_url implementation to return chat/completions paths
- Update model args creation to use chat/completions endpoint

Tests:
- Revise test assertions for _build_openai_url to expect chat/completions
- Update tests for _create_model_args to validate base_url values with chat/completions