### PR TITLE
feat: Fix model argument extraction in LMEvalCRBuilder

### DIFF
--- a/src/llama_stack_provider_lmeval/lmeval.py
+++ b/src/llama_stack_provider_lmeval/lmeval.py
@@ -361,10 +361,16 @@ class LMEvalCRBuilder:
         model_name = None
         if hasattr(benchmark_config, "model") and benchmark_config.model:
             model_name = benchmark_config.model
-        elif hasattr(benchmark_config, "eval_candidate") and benchmark_config.eval_candidate:
-            if hasattr(benchmark_config.eval_candidate, "model") and benchmark_config.eval_candidate.model:
+        elif (
+            hasattr(benchmark_config, "eval_candidate")
+            and benchmark_config.eval_candidate
+        ):
+            if (
+                hasattr(benchmark_config.eval_candidate, "model")
+                and benchmark_config.eval_candidate.model
+            ):
                 model_name = benchmark_config.eval_candidate.model
-        
+
         if model_name:
             model_args.append(ModelArg(name="model", value=model_name))
 

--- a/src/llama_stack_provider_lmeval/lmeval.py
+++ b/src/llama_stack_provider_lmeval/lmeval.py
@@ -358,8 +358,15 @@ class LMEvalCRBuilder:
         ]
 
         # Add model name if specified in benchmark config
+        model_name = None
         if hasattr(benchmark_config, "model") and benchmark_config.model:
-            model_args.append(ModelArg(name="model", value=benchmark_config.model))
+            model_name = benchmark_config.model
+        elif hasattr(benchmark_config, "eval_candidate") and benchmark_config.eval_candidate:
+            if hasattr(benchmark_config.eval_candidate, "model") and benchmark_config.eval_candidate.model:
+                model_name = benchmark_config.eval_candidate.model
+        
+        if model_name:
+            model_args.append(ModelArg(name="model", value=model_name))
 
         # Add custom model args from benchmark config, avoiding duplicate keys
         if hasattr(benchmark_config, "model_args") and benchmark_config.model_args:


### PR DESCRIPTION
## Summary by Sourcery

Support extracting the model argument from eval_candidate.model when benchmark_config.model is absent and add a test for it

Bug Fixes:
- Extract model name from eval_candidate.model if benchmark_config.model is not set

Tests:
- Add test to verify create_cr includes modelArg from eval_candidate.model