### PR TITLE
fix(RHOAIENG-32743): Add missing field `adapter_type` to AdapterSpec

### DIFF
--- a/src/llama_stack_provider_lmeval/provider.py
+++ b/src/llama_stack_provider_lmeval/provider.py
@@ -10,7 +10,7 @@ def get_provider_spec() -> ProviderSpec:
     return remote_provider_spec(
         api=Api.eval,
         adapter=AdapterSpec(
-            name="trustyai_lmeval",
+            adapter_type="lmeval",
             pip_packages=["kubernetes"],
             config_class="lmeval.config.LMEvalBenchmarkConfig",
             module="lmeval",


### PR DESCRIPTION
Refer to [RHOAIENG-32743](https://issues.redhat.com/browse/RHOAIENG-32743).