### PR TITLE
fix(RHOAIENG-32743): change config_class and module inside `AdapterSpec`

### DIFF
--- a/src/llama_stack_provider_lmeval/provider.py
+++ b/src/llama_stack_provider_lmeval/provider.py
@@ -10,9 +10,9 @@ def get_provider_spec() -> ProviderSpec:
     return remote_provider_spec(
         api=Api.eval,
         adapter=AdapterSpec(
-            name="trustyai_lmeval",
+            adapter_type="lmeval",
             pip_packages=["kubernetes"],
-            config_class="lmeval.config.LMEvalBenchmarkConfig",
-            module="lmeval",
+            config_class="llama_stack_provider_lmeval.config.LMEvalEvalProviderConfig",
+            module="llama_stack_provider_lmeval",
         ),
     )


### PR DESCRIPTION
Refer to [RHOAIENG-32743](https://issues.redhat.com/browse/RHOAIENG-32743) and [PR55](https://github.com/trustyai-explainability/llama-stack-provider-lmeval/pull/55)

While the previous PR correctly added missing field `adapter_type` in the `AdapterSpec`, it did not update the `config_class` and `module` fields

I created an image that can be used to test this change: quay.io/rh-ee-mmisiura/lls:lmeval_test_module_load_with_new_fix 

An image from [PR55](https://github.com/trustyai-explainability/llama-stack-provider-lmeval/pull/55) can be accessed here: quay.io/rh-ee-mmisiura/lls:llmeval_test_module_testpy_55

## Summary by Sourcery

Fix AdapterSpec configuration by replacing the deprecated name field with adapter_type and pointing config_class and module to the correct llama_stack_provider_lmeval paths.

Bug Fixes:
- Use adapter_type instead of name in AdapterSpec
- Update config_class and module to the llama_stack_provider_lmeval package paths