### PR TITLE
Pin Trivy action to specific commit version

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,7 +30,7 @@ jobs:
           python -m pip install -e ".[dev]"
 
       - name: Run Trivy filesystem scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -40,7 +40,7 @@ jobs:
           exit-code: '0'  # Don't fail on this scan, we'll check results separately
 
       - name: Run Trivy dependency scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -51,7 +51,7 @@ jobs:
           exit-code: '0'  # Don't fail on this scan, we'll check results separately
 
       - name: Check for critical and high vulnerabilities
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: '.'


### PR DESCRIPTION
Updated Trivy action version to a specific commit for consistency.

## Summary by Sourcery

CI:
- Update Trivy action references in the security workflow to use a fixed commit corresponding to version v0.35.0 instead of the master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning workflow configuration to use pinned versions for enhanced stability and reproducibility in automated security checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->